### PR TITLE
Add lxml[html_clean] as independent package 

### DIFF
--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -4,4 +4,4 @@ malariagen_data>=7.1.1
 # avoid backtracking problems
 jsonschema>=3
 jinja2>=3
-
+lxml[html_clean]


### PR DESCRIPTION
The deployment action is failing as `lxml.html.clean` has moved to a separate package. 

Details in: https://lxml.de/5.2/changes-5.2.0.html

> The lxml.html.clean implementation suffered from several (only if used) security issues in the past and was now extracted into a separate library:
> https://github.com/fedora-python/lxml_html_clean
> Projects that use lxml without "lxml.html.clean" will not notice any difference, except that they won't have potentially vulnerable code installed. The module is available as an "extra" setuptools dependency "lxml[html_clean]", so that Projects that need "lxml.html.clean" will need to switch their requirements from "lxml" to "lxml[html_clean]", or install the new library themselves.

It seems that upgrading from python3.8 to python3.10 would also solve this. As I am not sure if we are using py3.8 here for another reason, I'm just fixing the import for now. 