### PR TITLE
Update python version used by `check-book` 

### DIFF
--- a/.github/workflows/check-book.yml
+++ b/.github/workflows/check-book.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9.21
+        python-version: 3.9.23
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Addresses #108.

I tried `3.9.23` this time.