### PR TITLE
Update python version used by `gh-pages` 

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9.21
+        python-version: 3.9.23
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Addresses #110. New version: 3.9.23