### PR TITLE
Update Python version

### DIFF
--- a/.github/workflows/check-book.yml
+++ b/.github/workflows/check-book.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9.25
+        python-version: 3.10.19
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Still addresses #117 .

Turns out, it now seems to want at least 3.10.19. So here is a newer newer version.